### PR TITLE
[fix] Can't install application on iOS

### DIFF
--- a/install.html
+++ b/install.html
@@ -2,7 +2,7 @@
 <html>
     <head>
         <meta charset="UTF-8">
-        <title>{kus}</title>
+        <title>{Querek}</title>
         <meta name="viewport" content="width=device-width">
     <body>
         <div>
@@ -58,20 +58,33 @@
             /**
              * @function
              */
-            function detect() {
-                requestOptions = collectApplicationDetails();
-
+            function download() {
                 if (isAndroid()) {
-                    document.location = 'https://fdebd1a2.ngrok.io/app?type=' + requestOptions.type + '&version=' + requestOptions.version;
+                    downloadApk();
                 } else {
-                    document.location = 'itms-services://?action=download-manifest&amp;url=https://fdebd1a2.ngrok.io/manifest/' + requestOptions.type + '/' + requestOptions.version + '/manifest.plist';
+                    downloadIpa();
                 }
             }
 
+            /**
+             * @function
+             */
+            function downloadApk() {
+                requestOptions = collectApplicationDetails();
 
-            // LETS START
-            detect();
+                document.location = 'https://fdebd1a2.ngrok.io/app?type=' + requestOptions.type + '&version=' + requestOptions.version;
+            }
 
+            /**
+             * @function
+             */
+            function downloadIpa() {
+                requestOptions = collectApplicationDetails();
+
+                document.location = 'itms-services://?action=download-manifest&amp;url=https://fdebd1a2.ngrok.io/manifest/' + requestOptions.type + '/' + requestOptions.version + '/manifest.plist';
+            }
+
+            download();
 
         </script>
     </body>

--- a/install.html
+++ b/install.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <title>{kus}</title>
+        <meta name="viewport" content="width=device-width">
+    <body>
+        <div>
+            Detect your device!
+        </div>
+        <script>
+
+            /**
+             * Stores details like version and type of requested application
+             *
+             * @type {Object}
+             */
+            var requestOptions;
+
+
+            /**
+             * @function
+             * @returns {Array.<String>}
+             */
+            function collectSearchArguments() {
+                return document.location.search
+                        //removes "?" sign
+                        .slice(1, document.location.search.length)
+                        .split('&');
+            }
+
+
+            /**
+             * @function
+             * @returns {Object}
+             */
+            function collectApplicationDetails() {
+                var queries = collectSearchArguments();
+                var options = {};
+
+                queries.forEach(function (query) {
+                    options[query.split('=')[0]] = query.split('=')[1];
+                });
+
+                return options;
+            }
+
+
+            /**
+             * @function
+             * @returns {Boolean}
+             */
+            function isAndroid() {
+                return /android/.test(window.navigator.userAgent.toLowerCase());
+            }
+
+
+            /**
+             * @function
+             */
+            function detect() {
+                requestOptions = collectApplicationDetails();
+
+                if (isAndroid()) {
+                    document.location = 'https://fdebd1a2.ngrok.io/app?type=' + requestOptions.type + '&version=' + requestOptions.version;
+                } else {
+                    document.location = 'itms-services://?action=download-manifest&amp;url=https://fdebd1a2.ngrok.io/manifest/' + requestOptions.type + '/' + requestOptions.version + '/manifest.plist';
+                }
+            }
+
+
+            // LETS START
+            detect();
+
+
+        </script>
+    </body>
+</html>

--- a/install.html
+++ b/install.html
@@ -17,7 +17,6 @@
              */
             var requestOptions;
 
-
             /**
              * @function
              * @returns {Array.<String>}
@@ -28,7 +27,6 @@
                         .slice(1, document.location.search.length)
                         .split('&');
             }
-
 
             /**
              * @function
@@ -45,7 +43,6 @@
                 return options;
             }
 
-
             /**
              * @function
              * @returns {Boolean}
@@ -53,7 +50,6 @@
             function isAndroid() {
                 return /android/.test(window.navigator.userAgent.toLowerCase());
             }
-
 
             /**
              * @function

--- a/manifest.plist
+++ b/manifest.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>items</key>
+        <array>
+            <dict>
+                <key>assets</key>
+                <array>
+                    <dict>
+                        <key>kind</key>
+                        <string>software-package</string>
+                        <key>url</key>
+                        <string>https://fdebd1a2.ngrok.io/fitatu.ipa</string>
+                    </dict>
+                </array>
+                <key>metadata</key>
+                <dict>
+                    <key>bundle-identifier</key>
+                    <string>com.fitatu.tracker</string>
+                    <key>bundle-version</key>
+                    <string>2.0.11</string>
+                    <key>kind</key>
+                    <string>software</string>
+                    <key>title</key>
+                    <string>Fitatu</string>
+                </dict>
+            </dict>
+        </array>
+    </dict>
+</plist>

--- a/server.js
+++ b/server.js
@@ -219,7 +219,7 @@ app.get('/manifest/:type/:version/manifest.plist', function (req, res) {
 app.get('/fitatu.ipa', function (req, res) {
     var path = __dirname + '/apps/release/v2.0.14/Fitatu.ipa';
 
-    console.log('mime: ',     mime.lookup(path));
+    console.log('MMMime: ',     mime.lookup(path));
 
     res.setHeader("Content-Type", mime.lookup(path));
     res.sendFile(path);
@@ -229,28 +229,10 @@ app.get('/fitatu/:type/:version/fitatu.ipa', function (req, res) {
     // var platformExtension = getPlatformExtension(req.headers);
     var appDirPath = getFilePath(req.params.type, req.params.version);
 
-    console.log('mime: ',     mime.lookup(path));
+    console.log('IPA mime: ',     mime.lookup(appDirPath));
 
-    // -----
-
-    fs.readdir(appDirPath, function (err, list) {
-        list.forEach(function (file) {
-            // @example file = "Fitatu.ipa"
-            if ('ipa' > -1) {
-                console.log('file: ', file);
-
-                // browser downloads file named "app.ipa" or "app.apk" due to endpoint name
-                res.setHeader("Content-Type", mime.lookup(appDirPath + '/' + file));
-                res.sendFile(appDirPath + '/' + file);
-            }
-        });
-    });
-
-
-    // -----
-
-    // res.setHeader("Content-Type", mime.lookup(path));
-    // res.sendFile(path);
+    res.setHeader("Content-Type", mime.lookup(appDirPath + '/' + 'Fitatu.ipa'));
+    res.sendFile(appDirPath + '/' + 'Fitatu.ipa');
 });
 
 app.get('/app', function (req, res) {
@@ -335,36 +317,36 @@ function generatePlist(type, version) {
         '<?xml version="1.0" encoding="UTF-8"?>' +
         '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">' +
         '<plist version="1.0">' +
-        '<dict>' +
-        '<key>items</key>' +
-        '<array>' +
-        '<dict>' +
-        '<key>assets</key>' +
-        '<array>' +
-        '<dict>' +
-        '<key>kind</key>' +
-        '<string>software-package</string>' +
-        '<key>url</key>' +
-        // here server crashes while connecting variables
-        // '<string>https://fdebd1a2.ngrok.io/fitatu/' + type + '/' + version + '/fitatu.ipa</string>' +
-        // '<string>https://fdebd1a2.ngrok.io/fitatu/release/2.0.1/fitatu.ipa</string>' +
-        '<string>https://fdebd1a2.ngrok.io/fitatu.ipa</string>' +
-        '</dict>' +
-        '</array>' +
-        '<key>metadata</key>' +
-        '<dict>' +
-        '<key>bundle-identifier</key>' +
-        '<string>com.fitatu.tracker</string>' +
-        '<key>bundle-version</key>' +
-        '<string>2.0.3</string>' +
-        '<key>kind</key>' +
-        '<string>software</string>' +
-        '<key>title</key>' +
-        '<string>AppName</string>' +
-        '</dict>' +
-        '</dict>' +
-        '</array>' +
-        '</dict>' +
+            '<dict>' +
+                '<key>items</key>' +
+                '<array>' +
+                    '<dict>' +
+                        '<key>assets</key>' +
+                        '<array>' +
+                            '<dict>' +
+                            '<key>kind</key>' +
+                            '<string>software-package</string>' +
+                            '<key>url</key>' +
+                            // here server crashes while connecting variables
+                            '<string>https://551530d2.ngrok.io/fitatu/' + type + '/' + version + '/fitatu.ipa</string>' +
+                            // '<string>https://551530d2.ngrok.io/fitatu/release/v2.0.14/fitatu.ipa</string>' +
+                            // '<string>https://551530d2.ngrok.io/fitatu.ipa</string>' +
+                            '</dict>' +
+                        '</array>' +
+                        '<key>metadata</key>' +
+                        '<dict>' +
+                            '<key>bundle-identifier</key>' +
+                            '<string>com.fitatu.tracker</string>' +
+                            '<key>bundle-version</key>' +
+                            '<string>2.0.3</string>' +
+                            '<key>kind</key>' +
+                            '<string>software</string>' +
+                            '<key>title</key>' +
+                            '<string>AppName</string>' +
+                        '</dict>' +
+                    '</dict>' +
+                '</array>' +
+            '</dict>' +
         '</plist>';
 
     return xml;

--- a/server.js
+++ b/server.js
@@ -1,5 +1,5 @@
 /**
- * Simple server for {kuler} managing given files
+ * Simple server for {Querek} managing given files
  */
 var config      = require('./server.config');
 var express     = require('express');
@@ -7,8 +7,6 @@ var app         = require('express')();
 var mongoClient = require('mongodb').MongoClient;
 var assert      = require('assert');
 var http        = require('http').Server(app);
-
-// http https = require('https');
 
 var path        = require('path');
 var io          = require('socket.io')(http);
@@ -244,17 +242,17 @@ app.get('/app', function (req, res) {
 app.get('/application', function (req, res) {
     res.setHeader('APP-TYPE', req.query.type);
     res.setHeader('APP-VERSION', req.query.version);
+
     res.sendFile(__dirname  + '/install.html');
 });
 
 app.get('/application.ipa', function (req, res) {
+    var platformExtension = getPlatformExtension(req.headers);
+    var appDirPath = getFilePath(req.query.type, req.query.version);
 
     // tutorial https://gknops.github.io/adHocGenerate/#magiclink
     // local: http://192.168.0.87:3001/xxx?type=release&version=v2.0.11&t=3
     // remote: http://www.bitart.com/WirelessAdHocDemo/WirelessAdHocDemo.plist
-
-    var platformExtension = getPlatformExtension(req.headers);
-    var appDirPath = getFilePath(req.query.type, req.query.version);
 
     console.log('Query: ', req.query);
     console.log('platformExtension: ', platformExtension);

--- a/server.js
+++ b/server.js
@@ -163,11 +163,7 @@ function prepareAppForSaving(app) {
 }
 
 function writeFile(version, name, base64, type) {
-    fs.writeFile(
-        'apps/' + type + '/' + version + '/' + name,
-        base64,
-        'base64'
-    );
+    fs.writeFile('apps/' + type + '/' + version + '/' + name, base64, 'base64');
 }
 
 function getFilePath(type, version) {
@@ -180,6 +176,8 @@ function getPlatformExtension(headers) {
 
 // *******************  HANDLING PATHS *******************
 
+app.use('/', express.static('dist'));
+
 app.get('/', function (req, res) {
     res.send('QR Code Manager working at all');
 });
@@ -190,14 +188,8 @@ app.get('/manifest.plist', function (req, res) {
 });
 
 app.get('/manifest/:type/:version/manifest.plist', function (req, res) {
-
     console.log('TYPE: ', req.params.type);
     console.log('VERSION: ', req.params.version);
-
-    // console.log('MANIFEST: ', JSON.stringify(fs.readFileSync('manifest.plist', 'utf8')));
-
-    // res.setHeader("Content-Type", 'text/plain');
-    // res.sendFile(__dirname  + '/manifest.plist');
 
     fs.writeFile(__dirname  + '/manifest.plist', generatePlist(req.params.type, req.params.version), function (err) {
         if (err) {
@@ -209,27 +201,19 @@ app.get('/manifest/:type/:version/manifest.plist', function (req, res) {
             res.sendFile(__dirname  + '/manifest.plist');
         }
     });
-
-    // res.sendFile(plist.parse(generatePlist()));
 });
 
-//
-// Works
-//
 app.get('/fitatu.ipa', function (req, res) {
     var path = __dirname + '/apps/release/v2.0.14/Fitatu.ipa';
-
-    console.log('MMMime: ',     mime.lookup(path));
 
     res.setHeader("Content-Type", mime.lookup(path));
     res.sendFile(path);
 });
 
 app.get('/fitatu/:type/:version/fitatu.ipa', function (req, res) {
-    // var platformExtension = getPlatformExtension(req.headers);
     var appDirPath = getFilePath(req.params.type, req.params.version);
 
-    console.log('IPA mime: ',     mime.lookup(appDirPath));
+    console.log('IPA mime: ', mime.lookup(appDirPath));
 
     res.setHeader("Content-Type", mime.lookup(appDirPath + '/' + 'Fitatu.ipa'));
     res.sendFile(appDirPath + '/' + 'Fitatu.ipa');
@@ -250,7 +234,6 @@ app.get('/app', function (req, res) {
             if (file.indexOf(platformExtension) > -1) {
                 console.log('file: ', file);
                 // browser downloads file named "app.ipa" or "app.apk" due to endpoint name
-
                 res.setHeader("Content-Type", mime.lookup(appDirPath + '/' + file)); //Solution!
                 res.sendFile(appDirPath + '/' + file);
             }
@@ -258,24 +241,17 @@ app.get('/app', function (req, res) {
     });
 });
 
-app.use('/', express.static('dist'));
-
 app.get('/application', function (req, res) {
-    var platformExtension = getPlatformExtension(req.headers);
-    var appDirPath = getFilePath(req.query.type, req.query.version);
-
     res.setHeader('APP-TYPE', req.query.type);
     res.setHeader('APP-VERSION', req.query.version);
     res.sendFile(__dirname  + '/install.html');
 });
-
 
 app.get('/application.ipa', function (req, res) {
 
     // tutorial https://gknops.github.io/adHocGenerate/#magiclink
     // local: http://192.168.0.87:3001/xxx?type=release&version=v2.0.11&t=3
     // remote: http://www.bitart.com/WirelessAdHocDemo/WirelessAdHocDemo.plist
-
 
     var platformExtension = getPlatformExtension(req.headers);
     var appDirPath = getFilePath(req.query.type, req.query.version);
@@ -285,26 +261,10 @@ app.get('/application.ipa', function (req, res) {
     console.log('Applications dir: ', appDirPath);
     console.log('mime: ',     mime.lookup(appDirPath + '/Fitatu.ipa'));
 
-
     fs.readdir(appDirPath, function (err, list) {
         list.forEach(function (file) {
             // @example file = "Fitatu.apk"
             if (file.indexOf(platformExtension) > -1) {
-
-                console.log('file: ', file);
-
-                // browser downloads file named "app.ipa" or "app.apk" due to endpoint name
-
-                // res.setHeader("Content-Type", mime.lookup(appDirPath + '/Fitatu.ipa')); //Solution!
-                // res.setHeader("Content-Disposition", 'attachment'); //Solution!
-                // res.sendFile(appDirPath + '/' + file);
-
-                // res.sendFile(plist.parse(generatePlist()));
-
-
-                // res.setHeader("Content-Type", mime.lookup(appDirPath + '/Fitatu.ipa')); //Solution!
-                // res.setHeader("Content-Type", 'text/xml');
-
                 res.setHeader("Content-Type", 'text/plain');
                 res.sendFile(__dirname  + '/manifest.plist');
             }


### PR DESCRIPTION
On iOS, application must be hosted over https. Second diff is installing process, because appName.ipa can be installed by returned manifest.plist instead of simple returning appName.apk from server. 